### PR TITLE
fix: the kos-compat in kos-compat.h

### DIFF
--- a/include/deemon/util/kos-compat.h
+++ b/include/deemon/util/kos-compat.h
@@ -614,9 +614,9 @@ DeeSystem_DEFINE_strstr(dee_strstr)
 #undef format_vprintf
 #define format_vprintf DeeFormat_VPrintf
 #undef sprintf
-#define sprintf(buf, ...) ((Dee_ssize_t)(Dee_sprintf(buf, __VA_ARGS__) - (buf)))
+#define sprintf(buf, ...) ((Dee_ssize_t)(Dee_snprintf(buf, sizeof(buf), __VA_ARGS__) - (buf)))
 #undef vsprintf
-#define vsprintf(buf, format, args) ((Dee_ssize_t)(Dee_vsprintf(buf, format, args) - (buf)))
+#define vsprintf(buf, format, args) ((Dee_ssize_t)(Dee_vsnprintf(buf, sizeof(buf), format, args) - (buf)))
 #undef snprintf
 #define snprintf(buf, bufsize, ...) ((Dee_ssize_t)(Dee_snprintf(buf, bufsize, __VA_ARGS__) - (buf)))
 #undef vsnprintf


### PR DESCRIPTION
## Summary
Fix critical severity security issue in `include/deemon/util/kos-compat.h`.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | V-001 |
| **Severity** | CRITICAL |
| **Scanner** | multi_agent_ai |
| **Rule** | `V-001` |
| **File** | `include/deemon/util/kos-compat.h:617` |

**Description**: The kos-compat.h header redefines the standard sprintf and vsprintf macros to wrap Dee_sprintf and Dee_vsprintf respectively. Critically, neither macro accepts a buffer size parameter — they are direct replacements for the unsafe C standard sprintf/vsprintf functions. Any code that includes this header and calls sprintf(buf, ...) or vsprintf(buf, format, args) with a fixed-size buffer and attacker-influenced format data or arguments can overflow the destination buffer. Because this header is included across the codebase, this is a systemic issue affecting all callers.

## Changes
- `include/deemon/util/kos-compat.h`

## Verification
- [x] Build passes
- [x] Scanner re-scan confirms fix
- [x] LLM code review passed

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
